### PR TITLE
diverse keys allowed

### DIFF
--- a/js/deer-utils.js
+++ b/js/deer-utils.js
@@ -153,7 +153,25 @@ export default {
                                         continue Leaf;
                                     }
                                     else {
-                                        obj = Object.assign(obj, val);
+                                        // Assign this to the main object.
+                                        if(obj[k]) {
+                                            // It may be already there as an Array with some various labels
+                                            if (Array.isArray(obj[k])){
+                                                let deepMatch = false
+                                                for(const e of obj[k]) {
+                                                    if(e.name===val.name){
+                                                        deepMatch = true
+                                                        break
+                                                    }
+                                                }
+                                                if(!deepMatch) { obj[k].push(val) }
+                                            } else if (obj[k].name !== val.name) { // often undefined
+                                                obj[k] = [obj[k],val]
+                                            }
+                                        } else {
+                                            // or just tack it on
+                                            obj = Object.assign(obj, val);
+                                        }
                                     }
                                 }
                                 catch (err_1) { }


### PR DESCRIPTION
Changing the support in `expand()` from just matching the `key` to matching the value `name` as well. This would allow for annotations like this to not overwrite each other:

```json
{   ...  "body" : {
    "contributor" : {
        "value": "Capitol Records", "name": "Label"
    }
    }
}

{   ...  "body" : {
    "contributor" : {
        "value": "MC Ricky D", "name": "Collaborating Artist"
    }
    }
}

{   ...  "body" : {
    "contributor" : {
        "value": "Doug E. Fresh", "name": "Artist"
    }
    }
}
```

Instead they are assigned to the original object in an array.

```json
{ 
    "contributor" : [ 
        { "value": "Capitol Records", "name": "Label" },
        { "value": "MC Ricky D", "name": "Collaborating Artist" },
        { "value": "Doug E. Fresh", "name": "Artist" }
    ]
}
```