### PR TITLE
Duplicate Primitives

### DIFF
--- a/js/deer-record.js
+++ b/js/deer-record.js
@@ -272,7 +272,7 @@ export default class DeerReport {
             .filter(el => {
                 //If this is a DEER.PRIMITIVES entry DO NOT repeat it as an annotation.  
                 if (DEER.PRIMITIVES.includes(el.getAttribute(DEER.KEY))) {
-                    UTILS.warning("A DEER.PRIMITIVES entry was detected (" + DEER.KEY + ") attribute value '" + el.getAttribute(DEER.KEY) + "' detected during submission.  This input will be ignored.  See duplicate below. ", el)
+                    UTILS.warning("A DEER.PRIMITIVES entry was detected (" + el.getAttribute(DEER.KEY) + ") attribute value '" + el.getAttribute(DEER.KEY) + "' detected during submission.  This input will be ignored.  See duplicate below. ", el)
                 }
                 return !DEER.PRIMITIVES.includes(el.getAttribute(DEER.KEY))
             })

--- a/js/deer-record.js
+++ b/js/deer-record.js
@@ -272,7 +272,7 @@ export default class DeerReport {
             .filter(el => {
                 //If this is a DEER.PRIMITIVES entry DO NOT repeat it as an annotation.  
                 if (DEER.PRIMITIVES.includes(el.getAttribute(DEER.KEY))) {
-                    UTILS.warning("A DEER.PRIMITIVES entry was detected (" + el.getAttribute(DEER.KEY) + ") attribute value '" + el.getAttribute(DEER.KEY) + "' detected during submission.  This input will be ignored.  See duplicate below. ", el)
+                    UTILS.warning("A DEER.PRIMITIVES entry was detected (" + el.getAttribute(DEER.KEY) + ").  An annotation will not be created for this entry since it is directly on the entity.")
                 }
                 return !DEER.PRIMITIVES.includes(el.getAttribute(DEER.KEY))
             })


### PR DESCRIPTION
The original detection of primitives when creating the entity was correct.  However, they were not filtered out of the set of elements to become annotations after entity processing.  Now, elements containing DEER-KEY that are included in DEER.PRIMITIVES are filtered before being processed into annotations. 