### PR TITLE
Send `UPDATED` when new annotations are made or updated

### DIFF
--- a/js/deer-record.js
+++ b/js/deer-record.js
@@ -370,7 +370,7 @@ export default class DeerReport {
                     })
                 })
             return Promise.all(annotations).then(() => {
-                DEER.UTILS.broadcast(undefined,DEER.EVENTS.UPDATED, this.elem, entity)
+                UTILS.broadcast(undefined,DEER.EVENTS.UPDATED, this.elem, entity)
                 return entity
             })
         }).bind(this))

--- a/js/deer-record.js
+++ b/js/deer-record.js
@@ -369,7 +369,10 @@ export default class DeerReport {
                             if(anno.new_obj_state.creator)input.setAttribute(DEER.ATTRIBUTION, anno.new_obj_state.creator)
                     })
                 })
-            return Promise.all(annotations).then(() => entity)
+            return Promise.all(annotations).then(() => {
+                DEER.UTILS.broadcast(undefined,DEER.EVENTS.UPDATED, this.elem, entity)
+                return entity
+            })
         }).bind(this))
             .then(entity => {
                 this.elem.setAttribute(DEER.ID, entity["@id"])


### PR DESCRIPTION
This is small, but I'd like to see if it acts how you (@thehabes) are expecting. It does not fire when a form is initialized, but does when any annotations are made or changed. It fires once after all changed fields are saved and returned. It will not fire if there is an error in updating any single annotation or if none are changed.